### PR TITLE
s/nospecials/nospecial/ in POD

### DIFF
--- a/bin/genpass
+++ b/bin/genpass
@@ -145,7 +145,7 @@ such as period, exclamation mark, percentage sign, etc.
 
 You can negate this flag by doing:
 
-    genpass --nospecials
+    genpass --nospecial
 
 Default: no.
 


### PR DESCRIPTION
I noticed the docs had the negation of special as nospecials (with an extra s).

$ genpass --nospecial
4YKt5nYeLG

$ genpass --nospecials
Unknown option: nospecials
...

I was reading the docs because it didn't seem to be working.

$ genpass --special
Cannot have both special and readable characters. Pick one. at /usr/local/bin/genpass line 16

$ genpass --special --noreadable
me7z)XP(#*

Do you really want 'genpass -s' to not work without the --noreadable option also given? That doesn't seem right. I think 'genpass --special' ought to do what 'genpass --special --noreadable' does now.
