### PR TITLE
lib/App/Genpass.pm: add whitespace for 'C<< >>' POD

### DIFF
--- a/lib/App/Genpass.pm
+++ b/lib/App/Genpass.pm
@@ -441,8 +441,8 @@ After all the characters are set, unreadable characters will be removed from all
 sets.
 
 Thus, unreadable characters override all other sets. You can make unreadable
-characters not count by using the C<<readable => 0>> option, described by the
-I<readable> flag above.
+characters not count by using the C<< readable => 0 >> option, described by
+the I<readable> flag above.
 
 =item specials
 
@@ -468,14 +468,14 @@ to generate, defined by the attribute B<number> explained above.
 
 This method tries to be tricky and DWIM (or rather, DWYM). That is, if you
 request it to generate only one password and use scalar context
-(C<<my $p = $gp->generate(1)>>), it will return a single password.
+(C<< my $p = $gp->generate(1) >>), it will return a single password.
 
 However, if you try to generate multiple passwords and use scalar context
-(C<<my $p = $gp->generate(30)>>), it will return an array reference for the
+(C<< my $p = $gp->generate(30) >>), it will return an array reference for the
 passwords.
 
-Generating passwords with list context (C<<my @p = $gp->generate(...)>>) will
-always return a list of the passwords, even if it's a single password.
+Generating passwords with list context (C<< my @p = $gp->generate(...) >>)
+will always return a list of the passwords, even if it's a single password.
 
 =head2 get_config_from_file
 


### PR DESCRIPTION
- Added whitespace after the opening and before the closing double diamonds of the 'C<< $obj->method() >>' "code text" POD constructs; the requirement for leading/trailing whitespace is documented in http://perldoc.perl.org/perlpod.html#Formatting-Codes
- Verified changes using `dzil test --no-author-deps --release`
- I'm not sure if this was intentional, but testing required _Pod::Coverage::TrustPod_, and it's not listed as a dependency in `dzil.ini`
